### PR TITLE
chore: add missing type hints in addstar.py and scraper.py

### DIFF
--- a/addstar.py
+++ b/addstar.py
@@ -7,7 +7,7 @@ def get_repo_name(line):
     names = line[s+1:e].split('/')
     return names[0].strip() + '/' + names[1].strip()
 
-def addstar(file):
+def addstar(file) -> None:
     convert_lines = []
     with io.open(file, 'r', encoding='utf8') as f:
         lines = f.readlines()

--- a/scraper.py
+++ b/scraper.py
@@ -6,7 +6,7 @@ import requests
 import urllib.parse
 from pyquery import PyQuery as pq
 
-def scrape_url(url):
+def scrape_url(url: str):
     ''' Scrape github trending url
     '''
     HEADERS = {
@@ -34,7 +34,7 @@ def scrape_url(url):
         results[title] = { 'title': title, 'url': url, 'description': description }
     return results
 
-def scrape_lang(language):
+def scrape_lang(language) -> dict:
     ''' Scrape github trending with lang parameters
     '''
     url = 'https://github.com/trending/{language}'.format(language=urllib.parse.quote_plus(language))
@@ -43,7 +43,7 @@ def scrape_lang(language):
     r2 = scrape_url(url)
     return { **r1, **r2 }
 
-def write_markdown(lang, results, archived_contents):
+def write_markdown(lang, results, archived_contents) -> None:
     ''' Write the results to markdown file
     '''
     content = ''
@@ -53,7 +53,7 @@ def write_markdown(lang, results, archived_contents):
     with open('README.md', mode='w', encoding='utf-8') as f:
         f.write(content)
 
-def is_title_exist(title, content, archived_contents):
+def is_title_exist(title: str, content: str, archived_contents) -> bool:
     if '[' + title + ']' in content:
         return True
     for archived_content in archived_contents:
@@ -61,7 +61,7 @@ def is_title_exist(title, content, archived_contents):
             return True
     return False
 
-def convert_file_contenet(content, lang, results, archived_contents):
+def convert_file_contenet(content: str, lang, results, archived_contents):
     ''' Add distinct results to content
     '''
     distinct_results = []
@@ -90,14 +90,14 @@ def convert_result_content(results):
             description=format_description(result['description']))
     return content
 
-def format_description(description):
+def format_description(description: str) -> str:
     ''' Remove new line characters
     '''
     if not description:
         return ''
     return description.replace('\r', '').replace('\n', '')
 
-def convert_lang_title(lang):
+def convert_lang_title(lang) -> str:
     ''' Lang title
     '''
     if lang == '':
@@ -114,7 +114,7 @@ def get_archived_contents():
         archived_contents.append(content)
     return archived_contents
 
-def job():
+def job() -> None:
     ''' Get archived contents
     '''
     archived_contents = get_archived_contents()


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be made a bit more robust and readable. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Type hint additions
- `addstar.py`: added type hints to 1 function(s)
- `scraper.py`: added type hints to 8 function(s)

I have added basic type annotations based on variable names and default values. This should make the code easier to work with in modern IDEs without changing any of the actual logic.

### Examples of changes
**Example change in `addstar.py`:**
```diff
-def addstar(file):
+def addstar(file) -> None:
```

**Example change in `scraper.py`:**
```diff
-def scrape_url(url):
+def scrape_url(url: str):
-def scrape_lang(language):
+def scrape_lang(language) -> dict:
-def write_markdown(lang, results, archived_contents):
+def write_markdown(lang, results, archived_contents) -> None:
-def is_title_exist(title, content, archived_contents):
+def is_title_exist(title: str, content: str, archived_contents) -> bool:
-def convert_file_contenet(content, lang, results, archived_contents):
+def convert_file_contenet(content: str, lang, results, archived_contents):
-def format_description(description):
+def format_description(description: str) -> str:
... (truncated for brevity)
```

---

### Safety and verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- Files using dynamic patterns like `eval()` or `globals()` were automatically skipped.
- I did not modify any `__init__.py` files.

I hope these small improvements are helpful for the project.